### PR TITLE
テストの実行方法をトップページのREADMEから分離させる

### DIFF
--- a/01_ruby/README.md
+++ b/01_ruby/README.md
@@ -1,0 +1,35 @@
+# 01_ruby
+
+他言語からRubyへ入門する方などへ向けたRubyの基礎知識やRubyならではの特徴などを学習するためのドキュメントです。
+
+## テストの実行方法について
+
+rakeコマンドを通じてテストを実行する設計になっています。
+
+```sh
+% bundle install
+```
+
+で必要なライブラリをインストールしてから、rakeを実行します。本リポジトリではテストに対して実装が行われていない設計になっているため、テストが大量にfailしますが正しい状態です。
+
+```sh
+% bundle exec rake
+bundle exec rake
+Run options: --seed 64799
+
+# Running:
+
+EEEFEFEEEEEEEEEEEE
+
+Finished in 0.004522s, 3980.5396 runs/s, 442.2822 assertions/s.
+    :
+    :
+Tasks: TOP => default => test
+(See full trace by running task with --trace)
+```
+
+特定のディレクトリのみテストを実行したい場合はTEST環境変数を利用します。
+
+```sh
+% bundle exec rake TEST=test/03_private_symbol/*.rb
+```

--- a/README.md
+++ b/README.md
@@ -15,38 +15,6 @@ Yay!
   - Bundlerは2系のものを準備してください（Ruby 2.7であれば標準でBundler 2系がインストールされています）
 - Rails 6.0 以上
 
-## テストの実行方法について
-
-rakeコマンドを通じてテストを実行する設計になっています。
-
-```sh
-% bundle install
-```
-
-で必要なライブラリをインストールしてから、rakeを実行します。本リポジトリではテストに対して実装が行われていない設計になっているため、テストが大量にfailしますが正しい状態です。
-
-```sh
-% bundle exec rake
-bundle exec rake
-Run options: --seed 64799
-
-# Running:
-
-EEEFEFEEEEEEEEEEEE
-
-Finished in 0.004522s, 3980.5396 runs/s, 442.2822 assertions/s.
-    :
-    :
-Tasks: TOP => default => test
-(See full trace by running task with --trace)
-```
-
-特定のディレクトリのみテストを実行したい場合はTEST環境変数を利用します。
-
-```sh
-% bundle exec rake TEST=test/03_private_symbol/*.rb
-```
-
 ## Rubyのインストール方法
 
 新しいRubyが一番良いRubyなのでrbenvを使って新しいRubyを用意しておきましょう


### PR DESCRIPTION
よく考えたらテストの実行方法はRuby編にあるべきな気がしてきました 👁️ 👁️ 