### PR TITLE
Update minitest

### DIFF
--- a/01_ruby/Gemfile
+++ b/01_ruby/Gemfile
@@ -4,6 +4,6 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem "minitest", "~> 5.13"
+gem "minitest", "~> 5.18"
 
 gem "rake", "~> 13.0"

--- a/01_ruby/Gemfile.lock
+++ b/01_ruby/Gemfile.lock
@@ -1,15 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (5.14.1)
+    minitest (5.18.1)
     rake (13.0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  minitest (~> 5.13)
+  minitest (~> 5.18)
   rake (~> 13.0)
 
 BUNDLED WITH
-   2.0.2
+   2.4.14


### PR DESCRIPTION
minitest 5.14.1 は Ruby3 系で動かないため、2.6 以上を要求するバージョンへ更新しました