### PR TITLE
Rails や依存 gem のバージョンによる注意点を追加

### DIFF
--- a/02_rails/01_crud/README.md
+++ b/02_rails/01_crud/README.md
@@ -25,11 +25,28 @@ Chapter3ではCRUD機能を備えたアプリケーションをscaffoldを使わ
 
 前回と同じく `rails new` コマンドを使ってアプリケーションのひな形を作成します。
 
-今回は Ruby 2.5.1, Rails 5.2.1 を使っていくため、以下のようにバージョンを指定した上で `rails new` コマンドを実行してください。
+> [!IMPORTANT]
+> PostgreSQL を使用するために `-d postgresql` を指定してひな型を作成していますが、インストールの過程で以下のようなエラーが表示される場合があります。
+> ```
+> Installing pg 1.5.6 with native extensions
+> Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
+> ```
+> これはインストールの過程で PostgreSQL のクライアントライブラリが PC にインストールされていない場合に表示されるものです。  
+> エラー表示に従って `libpq` を導入して、改めて `bundle install` をすることで解決できます。
+ 
+#### バージョンを指定しない場合
 
-また、Ruby 2.5.1, Rails 5.2.1 をインストールしていない場合は事前にインストールをお願いします。
+特にバージョンを指定しない場合は、最新バージョンの Rails でセットアップされます。  
+Ruby 3.3.0, Rails 7.1.3.2 でも進めることは可能ですが、バージョンの違いによって修正が必要になる場合があります。
 
-※ 書籍とは異なる点なのでご注意ください
+```sh
+$ rails new taskleaf -d postgresql
+```
+
+#### バージョンを指定する場合
+
+バージョンを指定する場合は以下のように `rails new` コマンドを実行してください。  
+以下の例は書籍と異なるバージョン Ruby 2.5.1, Rails 5.2.1 を指定している例です。
 
 ```sh
 $ rbenv shell 2.5.1
@@ -113,11 +130,21 @@ taskleaf_development-# \q
 
 ### Bootstrap
 
-- フロントエンドフレームワークのひとつ
-- Rails5とRails6では導入方法に違いがあります
-  - Rails5までは bundler 経由で bootstrap gem を導入します
-    - 今回はこちらの方法を使います
-  - Rails6以降では npm/yarn 経由で bootstrap npm パッケージを導入します
+フロントエンドフレームワークのひとつ。  
+Rails 6 では npm/yarn + Webpacker を使う方法がありますが、Rails 5 および 7 以降では書籍と同じ bundler 経由の方法で進めることができますので、書籍通り進めてください。
+
+1つ異なる点として、書籍では `bootstrap` と同時に `sassc` がインストールされる前提になっていますが `bootstrap 5.3.3` 時点では同時にインストールされないようなので、実行時に以下のようなエラーが発生してしまいます。
+
+```
+bootstrap-rubygem requires a Sass engine. Please add dartsass-sprockets, sassc-rails, dartsass-rails or cssbundling-rails to your dependencies. (LoadError)
+```
+
+公式の [README](https://github.com/twbs/bootstrap-rubygem/blob/main/README.md) にしたがって `dartsass-sprockets` (Ruby 2.6 以降, Rails 5 以降に対応) を併せてインストールしてください。
+
+```
+gem 'bootstrap', '~> 5.3.3'
+gem 'dartsass-sprockets'
+```
 
 ## タスクモデルを作成する
 
@@ -176,3 +203,17 @@ edit_task GET    /tasks/:id/edit(.:format)   tasks#edit
 rails を起動した状態で http://localhost:3000/rails/info/routes にアクセスするとルーティングの定義が表示されます。
 
 ![screenshot](./rails_info_routes_sample.png)
+
+## method および confirm について
+
+Chapter 3-3-5 「削除機能を実装する」 において、`link_to` に `method` を指定して DELETE メソッドでリクエストさせるようにしている箇所がありますが、Rails 7 以降ではこの機能 (Rails UJS attributes) が廃止されています。  
+その代わりに Turbo という別の機能を使うことで実装できます。
+
+```erb
+<%# Rails 6 までの書き方 ( Rails 6 では非推奨 ) %>
+<%= link_to '削除', task, method: :delete, data: { confirm: "タスク「#{task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger' %>
+<%# Rails 7 以降の書き方 %>
+<%= link_to '削除', task, data: { turbo_method: :delete, turbo_confirm: "タスク「#{task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger' %>
+```
+
+これ以降の箇所においても `method` は `data.turbo_method` に、`data.confirm` は `data.turbo_confirm` に置き換えることで正常に動作するようになります。  

--- a/02_rails/01_crud/README.md
+++ b/02_rails/01_crud/README.md
@@ -146,6 +146,32 @@ gem 'bootstrap', '~> 5.3.3'
 gem 'dartsass-sprockets'
 ```
 
+#### JS の読み込み
+
+書籍内では特に使用する予定はありませんが、navbar の開閉やドロップダウンなどを使用したい場合は importmap-rails を使って読み込むことができます。
+
+1. `config/initializers/assets.rb` の `precompile` に追加
+   
+   ```diff
+   - # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+   + Rails.application.config.assets.precompile += %w( bootstrap.min.js popper.js )
+   ```
+2. `config/importmap.rb` の最終行に追加
+
+   ```ruby
+   pin "bootstrap", to: "bootstrap.min.js", preload: true
+   pin "@popperjs/core", to: "popper.js", preload: true
+   ```
+3. `app/javascript/application.js` で Bootstrap と popperjs を読み込み
+
+   ```js
+   import "@popperjs/core"
+   import "bootstrap"
+   ```
+
+> [!TIP]
+> 手順 2 はコマンド `bin/importmap pin bootstrap` で行うこともできますが、CDN からダウンロードされる `@popperjs/core` が他のファイルを読み込みに行こうとして 404 でエラーになってしまうので、gem から読み込む方法をおすすめします。
+
 ## タスクモデルを作成する
 
 > 参考: 現場で使える Ruby on Rails 5速習実践ガイド Chapter 3-2 p.92

--- a/02_rails/02_genjitsu/README.md
+++ b/02_rails/02_genjitsu/README.md
@@ -2,6 +2,34 @@
 
 「Chapter 4 現実の複雑さに対応する」の補足事項です
 
+## フォームのエラーが表示されない場合
+
+Rails 7 以降では Chapter 3 の補足でも触れた Turbo という機能がデフォルトで有効になっており、フォームの送信などが自動的に非同期で行われます。  
+この機能の副作用として、以下のようなコードにおいてブラウザのコンソールに `Form responses must redirect to another location` というエラーが表示され、フォームのエラー表示がうまく更新されない場合があります。
+
+```ruby
+def create
+  @task = current_user.tasks.new(task_params)
+  if @task.save
+    redirect_to @task, notice: "タスク「#{@task.name}」を登録しました。"
+  else
+    render :new
+  end
+end
+```
+
+これは Turbo の機能の一つ Turbo Drive が以下のような仕様であるためです([参考](https://github.com/domchristie/turbo/blob/c458b47c9f4c4bf48ae26f50a3d1bc88ad448039/src/core/drive/form_submission.js#L131-L142))。
+- フォーム自体はリダイレクトされることを期待している
+- 400番台 または 500番台 のエラーが返却された場合は画面を更新する
+  - tips: `render` はデフォルトでステータスコード 200 を返却する
+- それ以外の場合はエラー
+
+したがって、以下のように `status` を指定することでエラー表示が正しく更新されるようになります。
+
+```diff
+- render :new
++ render :new, status: :unprocessable_entity
+```
 
 ## 補足
 

--- a/02_rails/03_rspec/README.md
+++ b/02_rails/03_rspec/README.md
@@ -2,6 +2,36 @@
 
 「Chapter 5 テストをはじめよう」の補足事項です。
 
+## Turbo 環境においてテストが不安定な場合
+
+Rails 7 では Turbo がデフォルトで有効となっており、非同期にフォームの処理を行う関係で以下のようなログイン周りのテストの実行が不安定になる（スクリーンショットを確認すると、ログイン画面から遷移されずに止まった状態になっている など）傾向があります。
+
+```ruby
+before do
+  visit login_path
+  fill_in 'メールアドレス', with: login_user.email
+  fill_in 'パスワード', with: login_user.password
+  click_button 'ログイン'
+end
+```
+
+この場合、ログインボタンにIDを付与し、画面遷移によってログインボタンが非表示になるまで待機してから次の処理に進むことで解決する場合があります。
+
+```diff
+- <%= f.submit 'ログイン', class: 'btn btn-primary' %>
++ <%= f.submit 'ログイン', class: 'btn btn-primary', id: "login-button" %>
+```
+
+```diff
+  before do
+    visit login_path
+    fill_in 'メールアドレス', with: login_user.email
+    fill_in 'パスワード', with: login_user.password
+    click_button 'ログイン'
++   expect(page).not_to have_selector "#login-button"
+  end
+```
+
 ## 補足
 
 ### 表示形式を変える

--- a/02_rails/03_rspec/README.md
+++ b/02_rails/03_rspec/README.md
@@ -4,6 +4,32 @@
 
 ## 補足
 
+### 表示形式を変える
+
+デフォルトでは `...` のような形で実行結果が表示されますが、`--format documentation` ( 省略形: `-f d` ) を指定すると書籍に記載されているような形式で出力できます。
+
+```
+$ bundle exec rspec spec/system/tasks_spec.rb
+.....
+
+Finished in 7.14 seconds (files took 4.85 seconds to load)
+5 examples, 0 failures
+```
+
+```
+$ bundle exec rspec spec/system/tasks_spec.rb -f d
+
+タスク管理機能
+  一覧表示機能
+    ユーザーAがログインしているとき
+      behaves like ユーザーAが作成したタスクが表示される
+        is expected to have text "最初のタスク"
+(省略)
+
+Finished in 4.38 seconds (files took 1.91 seconds to load)
+5 examples, 0 failures
+```
+
 ### 一部のテストケースのみ実行する
 
 spec ファイル全体でなく、一部のテストケースのみ実行したい場合は以下のように指定できます。

--- a/02_rails/04_outline/README.md
+++ b/02_rails/04_outline/README.md
@@ -6,9 +6,11 @@
 
 ## フロントエンドについて
 
-Rails 5.2まではSprocetsを使ってJSのビルド・コンパイルを行っていましたが、Rails 6.0からJSはWebpackerを、CSSは引き続きSprocketsを使う体制になっています。
+JS や CSS の管理は Rails のバージョンによってメジャーなものが異なります。
 
-Webpackerはwebpackの薄いラッパーですが、Webpackerを使うといままでのSprocekts時代と同じ要領でビルドや配信、CSRF対策などができるのでWebpackerをそのまま使うかwebpackに切り替えるかはフロントエンドの習熟度や重要度に応じて検討すると良いでしょう。
+Rails 6 までは JS は Webpacker、CSS は sprockets を使う形式がメジャーでしたが、Webpacker は[すでに開発が終了](https://github.com/rails/webpacker#webpacker-has-been-retired-)しており、Rails 7 からは JS は importmap-rails、CSS は引き続き sprockets を使う形式がメジャーとなっています。
+
+このあたりは [アセットパイプライン - Rails ガイド](https://railsguides.jp/v7.1/asset_pipeline.html) なども含めて参照するとよいかと思います。
 
 ## `rails c` 便利Tips
 


### PR DESCRIPTION
Rails 7 にてチュートリアルを行った際にハマった点を中心に加筆しました。

- PostgreSQL の gem をインストールする際のエラーの対処方法を追加
- Bootstrap の読み込み方法を加筆
- Turbo 環境における `link_to` の `method` および `confirm` の指定方法を追加
- Turbo 環境におけるフォームのエラー反映が行われない場合の対処方法を追加
- テスト実行時の表示形式について加筆
- Webpacker の開発終了を明記し、importmap-rails について加筆
- Turbo 環境におけるフレーキー（不安定）なテストへの対処方法を追加